### PR TITLE
refactor: switch to sqlite

### DIFF
--- a/poetry.lock
+++ b/poetry.lock
@@ -856,10 +856,22 @@ files = [
 ]
 markers = {main = "extra == \"openai\""}
 
+[[package]]
+name = "xdg-base-dirs"
+version = "6.0.2"
+description = "Variables defined by the XDG Base Directory Specification"
+optional = false
+python-versions = "<4.0,>=3.10"
+groups = ["main"]
+files = [
+    {file = "xdg_base_dirs-6.0.2-py3-none-any.whl", hash = "sha256:3c01d1b758ed4ace150ac960ac0bd13ce4542b9e2cdf01312dcda5012cfebabe"},
+    {file = "xdg_base_dirs-6.0.2.tar.gz", hash = "sha256:950504e14d27cf3c9cb37744680a43bf0ac42efefc4ef4acf98dc736cab2bced"},
+]
+
 [extras]
 openai = ["openai"]
 
 [metadata]
 lock-version = "2.1"
 python-versions = ">=3.12,<4"
-content-hash = "97ac3b11fb233e092f7340da6e498136fd8356d8e05d48b3dd84fccad7bf5c91"
+content-hash = "833a717e5f89a247c39ca26ab6f4f04b17b25868c454f930aef5edb8e8b496e6"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -7,11 +7,12 @@ readme = 'README.md'
 dynamic = ['version']
 requires-python = '>=3.12'
 dependencies = [
-  'gitpython >=3.1.44,<4',
+  'gitpython (>=3.1.44,<4)',
+  "xdg-base-dirs (>=6.0.2,<7.0.0)",
 ]
 
 [project.optional-dependencies]
-openai = ['openai >=1.64.0,<2']
+openai = ['openai (>=1.64.0,<2)']
 
 [project.scripts]
 git-draft = 'git_draft.__main__:main'

--- a/src/git_draft/__main__.py
+++ b/src/git_draft/__main__.py
@@ -7,7 +7,7 @@ import sys
 import textwrap
 
 from .assistants import load_assistant
-from .common import open_editor
+from .common import Store, open_editor
 from .manager import Manager
 
 
@@ -41,9 +41,9 @@ def add_command(name: str, **kwargs) -> None:
     )
 
 
-add_command("discard", help="discard all drafts associated with a branch")
+add_command("discard", help="discard the current draft")
 add_command("finalize", help="apply the current draft to the original branch")
-add_command("generate", help="draft a new change from a prompt")
+add_command("generate", help="start a new draft from a prompt")
 
 parser.add_option(
     "-a",
@@ -61,7 +61,7 @@ parser.add_option(
 parser.add_option(
     "-d",
     "--delete",
-    help="delete the draft after finalizing or discarding",
+    help="delete draft after finalizing or discarding",
     action="store_true",
 )
 parser.add_option(
@@ -76,6 +76,12 @@ parser.add_option(
     help="reset index before generating a new draft",
     action="store_true",
 )
+parser.add_option(
+    "-s",
+    "--sync",
+    help="commit prior worktree changes separately",
+    action="store_true",
+)
 
 
 EDITOR_PLACEHOLDER = """\
@@ -86,7 +92,7 @@ EDITOR_PLACEHOLDER = """\
 def main() -> None:
     (opts, _args) = parser.parse_args()
 
-    manager = Manager.enclosing()
+    manager = Manager.create(Store.persistent())
 
     command = getattr(opts, "command", "generate")
     if command == "generate":

--- a/src/git_draft/assistants/__init__.py
+++ b/src/git_draft/assistants/__init__.py
@@ -1,3 +1,8 @@
+"""Assistant interfaces and built-in implementations
+
+* https://aider.chat/docs/leaderboards/
+"""
+
 from typing import Any, Mapping
 
 from .common import Assistant, Session, Toolbox

--- a/src/git_draft/assistants/common.py
+++ b/src/git_draft/assistants/common.py
@@ -6,6 +6,10 @@ from typing import Protocol, Sequence
 
 
 class Toolbox(Protocol):
+    # TODO: Something similar to https://aider.chat/docs/repomap.html,
+    # including inferring the most important files, and allowing returning
+    # signature-only versions.
+
     def list_files(self) -> Sequence[PurePosixPath]: ...
     def read_file(self, path: PurePosixPath) -> str: ...
     def write_file(self, path: PurePosixPath, contents: str) -> None: ...

--- a/src/git_draft/assistants/openai.py
+++ b/src/git_draft/assistants/openai.py
@@ -87,6 +87,7 @@ class OpenAIAssistant(Assistant):
 
     * https://platform.openai.com/docs/assistants/tools/function-calling
     * https://platform.openai.com/docs/assistants/deep-dive#runs-and-run-steps
+    * https://platform.openai.com/docs/api-reference/assistants-streaming/events
     * https://github.com/openai/openai-python/blob/main/src/openai/resources/beta/threads/runs/runs.py
     """
 

--- a/src/git_draft/common.py
+++ b/src/git_draft/common.py
@@ -1,8 +1,18 @@
+from __future__ import annotations
+
+import contextlib
+import functools
 import os
+from pathlib import Path
+import random
 import shutil
+import sqlite3
 import subprocess
+import string
 import sys
 import tempfile
+from typing import ContextManager
+import xdg_base_dirs
 
 
 _default_editors = ["vim", "emacs", "nano"]
@@ -43,3 +53,50 @@ def open_editor(placeholder="") -> str:
 
         with open(temp.name, mode="r") as reader:
             return reader.read()
+
+
+NAMESPACE = "git-draft"
+
+
+def _ensure_state_home() -> Path:
+    path = xdg_base_dirs.xdg_state_home() / NAMESPACE
+    path.mkdir(parents=True, exist_ok=True)
+    return path
+
+
+class Store:
+    _name = "db.v1.sqlite3"
+
+    def __init__(self, conn: sqlite3.Connection) -> None:
+        self._connection = conn
+
+    @classmethod
+    def persistent(cls) -> Store:
+        path = _ensure_state_home() / cls._name
+        conn = sqlite3.connect(str(path), autocommit=False)
+        return cls(conn)
+
+    @classmethod
+    def in_memory(cls) -> Store:
+        return cls(sqlite3.connect(":memory:"))
+
+    def cursor(self) -> ContextManager[sqlite3.Cursor]:
+        return contextlib.closing(self._connection.cursor())
+
+
+_query_root = Path(__file__).parent / "queries"
+
+
+@functools.cache
+def sql(name: str) -> str:
+    path = _query_root / f"{name}.sql"
+    with open(path) as reader:
+        return reader.read()
+
+
+_random = random.Random()
+_alphabet = string.ascii_lowercase + string.digits
+
+
+def random_id(n: int) -> str:
+    return "".join(_random.choices(_alphabet, k=n))

--- a/src/git_draft/queries/add-branch.sql
+++ b/src/git_draft/queries/add-branch.sql
@@ -1,0 +1,2 @@
+insert into branches (suffix, origin_branch, origin_sha, sync_sha)
+  values (:suffix, :origin_branch, :origin_sha, :sync_sha);

--- a/src/git_draft/queries/add-commit.sql
+++ b/src/git_draft/queries/add-commit.sql
@@ -1,0 +1,2 @@
+insert into commits (sha, prompt_id, token_count, walltime)
+  values (:sha, :prompt_id, :token_count, :walltime);

--- a/src/git_draft/queries/add-prompt.sql
+++ b/src/git_draft/queries/add-prompt.sql
@@ -1,0 +1,3 @@
+insert into prompts (branch_suffix, contents)
+  values (:branch_suffix, :contents)
+  returning id;

--- a/src/git_draft/queries/create-tables.sql
+++ b/src/git_draft/queries/create-tables.sql
@@ -1,0 +1,24 @@
+create table if not exists branches (
+  suffix text primary key,
+  created_at timestamp default current_timestamp,
+  origin_branch text not null,
+  origin_sha text not null,
+  sync_sha text
+) without rowid;
+
+create table if not exists prompts (
+  id integer primary key,
+  created_at timestamp default current_timestamp,
+  branch_suffix text not null,
+  contents text not null,
+  foreign key (branch_suffix) references branches(suffix)
+);
+
+create table if not exists commits (
+  sha text primary key,
+  created_at timestamp default current_timestamp,
+  prompt_id integer not null,
+  token_count int not null,
+  walltime real not null,
+  foreign key (prompt_id) references prompts(id)
+) without rowid;

--- a/src/git_draft/queries/get-branch-by-suffix.sql
+++ b/src/git_draft/queries/get-branch-by-suffix.sql
@@ -1,0 +1,3 @@
+select origin_branch, origin_sha, sync_sha
+  from branches
+  where suffix = :suffix;

--- a/tests/git_draft/common_test.py
+++ b/tests/git_draft/common_test.py
@@ -1,0 +1,32 @@
+import pytest
+import tempfile
+from typing import Iterator
+
+import git_draft.common as sut
+
+
+@pytest.fixture(autouse=True)
+def state_home(monkeypatch) -> Iterator[str]:
+    with tempfile.TemporaryDirectory() as name:
+        monkeypatch.setenv("XDG_STATE_HOME", name)
+        yield name
+
+
+def test_ensure_state_home(state_home) -> None:
+    path = sut._ensure_state_home()
+    assert path.exists()
+
+
+class TestStore:
+    def test_cursor(self) -> None:
+        store = sut.Store.persistent()
+        with store.cursor() as cursor:
+            cursor.execute("create table foo(id int)")
+            cursor.execute("insert into foo values (1), (2)")
+        with store.cursor() as cursor:
+            data = cursor.execute("select * from foo")
+            assert list(data) == [(1,), (2,)]
+
+
+def test_sql() -> None:
+    assert "create" in sut.sql("create-tables")


### PR DESCRIPTION
This will be needed to support application-wide configurations, for example to enable reusing OpenAI assistants. Another benefit is that is allows us to reduce our reliance on (and the number of) commits.