### PR TITLE
feat: improve merge behavior

### DIFF
--- a/docs/git-draft.adoc
+++ b/docs/git-draft.adoc
@@ -74,10 +74,6 @@ git draft [options] --show-templates [--json | [--edit] TEMPLATE]
   Lists available templates.
   With an template name argument, displays the corresponding template's contents or, if the `--edit` option is set, opens an interactive editor.
 
--t TIMEOUT::
---timeout=TIMEOUT::
-  Action timeout.
-
 --version::
   Show version and exit.
 

--- a/src/git_draft/__main__.py
+++ b/src/git_draft/__main__.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 from collections.abc import Sequence
+import enum
 import importlib.metadata
 import logging
 import optparse
@@ -11,7 +12,7 @@ import sys
 
 from .bots import load_bot
 from .common import PROGRAM, Config, UnreachableError, ensure_state_home
-from .drafter import Accept, Drafter
+from .drafter import Drafter
 from .editor import open_editor
 from .git import Repo
 from .prompt import Template, TemplatedPrompt, find_template, templates_table
@@ -97,6 +98,24 @@ def new_parser() -> optparse.OptionParser:
     )
 
     return parser
+
+
+class Accept(enum.Enum):
+    """Valid change accept mode"""
+
+    MANUAL = 0
+    MERGE = enum.auto()
+    MERGE_THEIRS = enum.auto()
+    FINALIZE = enum.auto()
+
+    def merge_strategy(self) -> str | None:
+        match self.value:
+            case Accept.MANUAL:
+                return None
+            case Accept.MERGE:
+                return "ignore-all-space"
+            case _:
+                return "theirs"
 
 
 class ToolPrinter(ToolVisitor):

--- a/src/git_draft/__main__.py
+++ b/src/git_draft/__main__.py
@@ -12,7 +12,7 @@ import sys
 
 from .bots import load_bot
 from .common import PROGRAM, Config, UnreachableError, ensure_state_home
-from .drafter import Drafter
+from .drafter import Drafter, DraftMergeStrategy
 from .editor import open_editor
 from .git import Repo
 from .prompt import Template, TemplatedPrompt, find_template, templates_table
@@ -108,7 +108,7 @@ class Accept(enum.Enum):
     MERGE_THEIRS = enum.auto()
     FINALIZE = enum.auto()
 
-    def merge_strategy(self) -> str | None:
+    def merge_strategy(self) -> DraftMergeStrategy | None:
         match self.value:
             case Accept.MANUAL:
                 return None

--- a/src/git_draft/__main__.py
+++ b/src/git_draft/__main__.py
@@ -95,11 +95,6 @@ def new_parser() -> optparse.OptionParser:
         action="store_const",
         const=0,
     )
-    parser.add_option(
-        "--timeout",
-        dest="timeout",
-        help="generation timeout",
-    )
 
     return parser
 
@@ -199,17 +194,17 @@ def main() -> None:  # noqa: PLR0912 PLR0915
             drafter.generate_draft(
                 prompt,
                 bot,
-                accept=accept,
-                bot_name=opts.bot,
                 prompt_transform=open_editor if editable else None,
+                merge_strategy=accept.merge_strategy(),
                 tool_visitors=[ToolPrinter()],
             )
             match accept:
                 case Accept.MANUAL:
                     print("Generated draft.")
-                case Accept.MERGE:
+                case Accept.MERGE | Accept.MERGE_THEIRS:
                     print("Merged draft.")
                 case Accept.FINALIZE:
+                    drafter.finalize_folio()
                     print("Finalized draft.")
                 case _:
                     raise UnreachableError()

--- a/src/git_draft/bots/common.py
+++ b/src/git_draft/bots/common.py
@@ -14,7 +14,7 @@ class Goal:
     """Bot request"""
 
     prompt: str
-    timeout: float | None
+    # TODO: Add timeout.
 
 
 @dataclasses.dataclass

--- a/src/git_draft/drafter.py
+++ b/src/git_draft/drafter.py
@@ -5,7 +5,6 @@ from __future__ import annotations
 from collections.abc import Callable, Sequence
 import dataclasses
 from datetime import datetime, timedelta
-import enum
 import json
 import logging
 from pathlib import PurePosixPath
@@ -22,24 +21,6 @@ from .toolbox import RepoToolbox, ToolVisitor
 
 
 _logger = logging.getLogger(__name__)
-
-
-class Accept(enum.Enum):
-    """Valid change accept mode"""
-
-    MANUAL = 0
-    MERGE = enum.auto()
-    MERGE_THEIRS = enum.auto()
-    FINALIZE = enum.auto()
-
-    def merge_strategy(self) -> str | None:
-        match self.value:
-            case Accept.MANUAL:
-                return None
-            case Accept.MERGE:
-                return "ignore-all-space"
-            case _:
-                return "theirs"
 
 
 @dataclasses.dataclass(frozen=True)

--- a/src/git_draft/git.py
+++ b/src/git_draft/git.py
@@ -50,9 +50,10 @@ class GitCall:
         stdout, stderr = popen.communicate(input=stdin)
         code = popen.returncode
         if expect_codes and code not in expect_codes:
-            raise GitError(
-                f"Git command failed with code {code}\n{stderr}\n{stdout}"
-            )
+            message = f"Git command failed with code exit {code}: {stderr}"
+            if stdout:
+                message += f"\n{stdout}"
+            raise GitError(message)
         return cls(code, stdout.rstrip(), stderr.rstrip())
 
 

--- a/src/git_draft/queries/add-action.sql
+++ b/src/git_draft/queries/add-action.sql
@@ -1,7 +1,6 @@
 insert into actions (
     commit_sha,
     prompt_id,
-    bot_name,
     bot_class,
     walltime_seconds,
     request_count,
@@ -9,7 +8,6 @@ insert into actions (
   values (
     :commit_sha,
     :prompt_id,
-    :bot_name,
     :bot_class,
     :walltime_seconds,
     :request_count,

--- a/src/git_draft/queries/create-tables.sql
+++ b/src/git_draft/queries/create-tables.sql
@@ -23,7 +23,6 @@ create table if not exists actions (
   commit_sha text primary key,
   created_at timestamp default current_timestamp,
   prompt_id integer not null,
-  bot_name text,
   bot_class text not null,
   walltime_seconds real not null,
   request_count int,

--- a/tests/git_draft/drafter_test.py
+++ b/tests/git_draft/drafter_test.py
@@ -6,7 +6,7 @@ import pytest
 
 from git_draft.bots import Action, Bot, Goal, Toolbox
 import git_draft.drafter as sut
-from git_draft.git import SHA, Repo
+from git_draft.git import SHA, GitError, Repo
 from git_draft.store import Store
 
 from .conftest import RepoFS
@@ -73,12 +73,58 @@ class TestDrafter:
 
     def test_generate_draft_merge(self) -> None:
         self._fs.write("p1", "a")
+
         self._drafter.generate_draft(
-            "hello", _SimpleBot({"p2": "b"}), merge_strategy="theirs"
+            "hello", _SimpleBot({"p2": "b"}), merge_strategy="ignore-all-space"
         )
-        assert len(self._commits()) == 5  # init, sync, prompt, sync, merge
+        # No sync(merge) commit since no changes happened between.
+        assert len(self._commits()) == 4  # init, sync(prompt), prompt, merge
         assert self._fs.read("p1") == "a"
         assert self._fs.read("p2") == "b"
+
+    def test_generate_draft_merge_no_conflict(self) -> None:
+        self._fs.write("p1", "a")
+
+        def update(_goal: Goal) -> str:
+            self._fs.write("p2", "b")
+            return "A"
+
+        self._drafter.generate_draft(
+            "hello",
+            _SimpleBot({"p1": update}),
+            merge_strategy="ignore-all-space",
+        )
+        assert len(self._commits()) == 5  # init, sync, prompt, sync, merge
+        assert self._fs.read("p1") == "A"
+        assert self._fs.read("p2") == "b"
+
+    def test_generate_draft_merge_theirs(self) -> None:
+        self._fs.write("p1", "a")
+
+        def update(_goal: Goal) -> str:
+            self._fs.write("p1", "b")
+            return "A"
+
+        self._drafter.generate_draft(
+            "hello", _SimpleBot({"p1": update}), merge_strategy="theirs"
+        )
+        # sync(merge) commit here since p1 was updated separately.
+        assert len(self._commits()) == 5  # init, sync, prompt, sync, merge
+        assert self._fs.read("p1") == "A"
+
+    def test_generate_draft_merge_conflict(self) -> None:
+        self._fs.write("p1", "a")
+
+        def update(_goal: Goal) -> str:
+            self._fs.write("p1", "b")
+            return "A"
+
+        with pytest.raises(GitError):
+            self._drafter.generate_draft(
+                "hello",
+                _SimpleBot({"p1": update}),
+                merge_strategy="ignore-all-space",
+            )
 
     def test_generate_outside_branch(self) -> None:
         self._repo.git("checkout", "--detach")

--- a/tests/git_draft/drafter_test.py
+++ b/tests/git_draft/drafter_test.py
@@ -71,26 +71,13 @@ class TestDrafter:
         assert len(self._commits()) == 1
         assert len(self._commits("@{u}")) == 2
 
-    def test_generate_draft_accept_merge(self) -> None:
+    def test_generate_draft_merge(self) -> None:
         self._fs.write("p1", "a")
         self._drafter.generate_draft(
-            "hello",
-            _SimpleBot({"p2": "b"}),
-            accept=sut.Accept.MERGE,
+            "hello", _SimpleBot({"p2": "b"}), merge_strategy="theirs"
         )
         assert len(self._commits()) == 5  # init, sync, prompt, sync, merge
         assert self._fs.read("p1") == "a"
-        assert self._fs.read("p2") == "b"
-
-    def test_generate_draft_accept_finalize(self) -> None:
-        self._fs.write("p1", "a")
-        self._drafter.generate_draft(
-            "hello",
-            _SimpleBot({"p1": "A", "p2": "b"}),
-            accept=sut.Accept.FINALIZE,
-        )
-        assert len(self._commits()) == 1  # init
-        assert self._fs.read("p1") == "A"
         assert self._fs.read("p2") == "b"
 
     def test_generate_outside_branch(self) -> None:
@@ -104,8 +91,8 @@ class TestDrafter:
 
     def test_generate_reuse_branch(self) -> None:
         bot = _SimpleBot({"prompt": lambda goal: goal.prompt})
-        self._drafter.generate_draft("prompt1", bot, sut.Accept.MERGE)
-        self._drafter.generate_draft("prompt2", bot, sut.Accept.MERGE)
+        self._drafter.generate_draft("prompt1", bot, "theirs")
+        self._drafter.generate_draft("prompt2", bot, "theirs")
         assert self._fs.read("prompt") == "prompt2"
 
     def test_delete_unknown_file(self) -> None:
@@ -113,9 +100,7 @@ class TestDrafter:
 
     def test_finalize_keeps_changes(self) -> None:
         self._fs.write("p1.txt", "a1")
-        self._drafter.generate_draft(
-            "hello", _SimpleBot.prompt(), sut.Accept.MERGE
-        )
+        self._drafter.generate_draft("hello", _SimpleBot.prompt(), "theirs")
         self._fs.write("p1.txt", "a2")
         self._drafter.finalize_folio()
         assert self._fs.read("p1.txt") == "a2"


### PR DESCRIPTION
When merging, we use the `sync(prompt)` commit as parent to prevent inaccurate conflicts due to prior changes.